### PR TITLE
Point rules file at canonical brand comms/ registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # Style Guide
 
+---
+> **Canonical comms rules:** facts, approved claims, metrics phrasings, naming, and legal red lines for ALL external communication live in `fabrica-land/brand` under `comms/` (`facts.md`, `voice-core.md`, `canonical-ownership.md`). This file holds only legal/trust-representation-specific rules. On any conflict, brand `comms/` wins. (Introduced with fabrica-land/brand PR #5.)
+---
+
 ## Terminology
 
 - **onchain** — one word, no hyphen. Not "on-chain."


### PR DESCRIPTION
## What this is

The `fabrica-land/brand` repo is being established as the single source of truth for everything that must stay consistent across ALL of Fabrica's external surfaces (app copy, help center, developer docs, lifecycle emails, marketing, legal representations): approved facts and claims, metrics phrasings, naming conventions, and legal red lines. That registry lives in `fabrica-land/brand` under `comms/` (`facts.md`, `voice-core.md`, `canonical-ownership.md`) and was introduced with fabrica-land/brand PR #5.

## What this PR does

Adds a short pointer preamble at the top of this repo's writing/agent rules file so that anyone (human or AI agent) writing content from this repo knows:

1. Cross-surface facts, claims, metrics, naming, and legal phrasings are defined centrally in brand `comms/`, not here.
2. This file keeps only the rules specific to this surface.
3. On any conflict between this file and brand `comms/`, brand `comms/` wins.

No other content in the file is changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
